### PR TITLE
Change polynomial types and simplify generic POLYVAL

### DIFF
--- a/benchmark/src/aarch64/polyval-pmull_asm.S
+++ b/benchmark/src/aarch64/polyval-pmull_asm.S
@@ -276,7 +276,7 @@ GSTAR	.req	v24
  * If op1, op2 are in montgomery form,  this computes the montgomery
  * form of op1*op2.
  *
- * void pmull_polyval_mul(u128* op1, const u128* op2);
+ * void pmull_polyval_mul(ble128* op1, const ble128* op2);
  */
 ENTRY(pmull_polyval_mul)
 	adr		TMP, .Lgstar
@@ -305,7 +305,7 @@ ENDPROC(pmull_polyval_mul)
  * x3 - final block (if nbytes % 16 != 0) used to allow padding without modifying *in
  * x4 - location to XOR with evaluated polynomial
  *
- * void pmull_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, const u8* final, u128* accumulator);
+ * void pmull_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, const u8* final, ble128* accumulator);
  */
 ENTRY(pmull_polyval_update)
 	adr		TMP, .Lgstar

--- a/benchmark/src/hctr2-xctr.c
+++ b/benchmark/src/hctr2-xctr.c
@@ -36,7 +36,7 @@ asmlinkage void ce_aes_xctr_encrypt(u8 out[], u8 const in[], u8 const rk[],
 static void xctr_crypt_simd(const struct aes_ctx *ctx, u8 *dst, const u8 *src,
 		     size_t nbytes, const u8 *iv)
 {
-	u128 extra;
+	le128 extra;
 	size_t offset;
 #ifdef __x86_64__
     switch(ctx->aes_ctx.key_length) {
@@ -88,7 +88,7 @@ static void xctr_crypt_generic(const struct aes_ctx *ctx, u8 *dst, const u8 *src
 	int i;
 	int nblocks;
 	size_t offset;
-	u128 ctr;
+	le128 ctr;
 
 	nblocks = nbytes / XCTR_BLOCK_SIZE;
 	for (i = 0; i < nblocks; i++) {

--- a/benchmark/src/hctr2.c
+++ b/benchmark/src/hctr2.c
@@ -19,9 +19,9 @@
 struct hctr2_ctx {
 	struct aes_ctx aes_ctx;
 	unsigned int default_tweak_len;
-	union polyval_key polyval_key;
+	struct polyval_key polyval_key;
 	u8 L[BLOCKCIPHER_BLOCK_SIZE];
-	union polyval_state initial_states[2];
+	struct polyval_state initial_states[2];
 };
 
 /*
@@ -68,7 +68,7 @@ void hctr2_setkey(struct hctr2_ctx *ctx, const u8 *key, size_t key_len,
 }
 
 static void hctr2_hash_tweak(const struct hctr2_ctx *ctx,
-			     union polyval_state *state, const u8 *data,
+			     struct polyval_state *state, const u8 *data,
 			     size_t nbytes, bool simd)
 {
 	u8 padded_final[POLYVAL_BLOCK_SIZE];
@@ -83,7 +83,7 @@ static void hctr2_hash_tweak(const struct hctr2_ctx *ctx,
 }
 
 static void hctr2_hash_message(const struct hctr2_ctx *ctx,
-			       union polyval_state *state, const u8 *data,
+			       struct polyval_state *state, const u8 *data,
 			       size_t nbytes, bool simd)
 {
 	u8 padded_final[POLYVAL_BLOCK_SIZE];
@@ -102,8 +102,8 @@ void hctr2_crypt(const struct hctr2_ctx *ctx, u8 *dst, const u8 *src,
 		 size_t nbytes, const u8 *tweak, size_t tweak_len, bool encrypt,
 		 bool simd)
 {
-	union polyval_state polystate1;
-	union polyval_state polystate2;
+	struct polyval_state polystate1;
+	struct polyval_state polystate2;
 	u8 digest[POLYVAL_DIGEST_SIZE];
 	u8 MM[BLOCKCIPHER_BLOCK_SIZE];
 	u8 UU[BLOCKCIPHER_BLOCK_SIZE];

--- a/benchmark/src/hctr2.c
+++ b/benchmark/src/hctr2.c
@@ -19,9 +19,9 @@
 struct hctr2_ctx {
 	struct aes_ctx aes_ctx;
 	unsigned int default_tweak_len;
-	struct polyval_key polyval_key;
+	union polyval_key polyval_key;
 	u8 L[BLOCKCIPHER_BLOCK_SIZE];
-	struct polyval_state initial_states[2];
+	union polyval_state initial_states[2];
 };
 
 /*
@@ -68,7 +68,7 @@ void hctr2_setkey(struct hctr2_ctx *ctx, const u8 *key, size_t key_len,
 }
 
 static void hctr2_hash_tweak(const struct hctr2_ctx *ctx,
-			     struct polyval_state *state, const u8 *data,
+			     union polyval_state *state, const u8 *data,
 			     size_t nbytes, bool simd)
 {
 	u8 padded_final[POLYVAL_BLOCK_SIZE];
@@ -83,7 +83,7 @@ static void hctr2_hash_tweak(const struct hctr2_ctx *ctx,
 }
 
 static void hctr2_hash_message(const struct hctr2_ctx *ctx,
-			       struct polyval_state *state, const u8 *data,
+			       union polyval_state *state, const u8 *data,
 			       size_t nbytes, bool simd)
 {
 	u8 padded_final[POLYVAL_BLOCK_SIZE];
@@ -102,8 +102,8 @@ void hctr2_crypt(const struct hctr2_ctx *ctx, u8 *dst, const u8 *src,
 		 size_t nbytes, const u8 *tweak, size_t tweak_len, bool encrypt,
 		 bool simd)
 {
-	struct polyval_state polystate1;
-	struct polyval_state polystate2;
+	union polyval_state polystate1;
+	union polyval_state polystate2;
 	u8 digest[POLYVAL_DIGEST_SIZE];
 	u8 MM[BLOCKCIPHER_BLOCK_SIZE];
 	u8 UU[BLOCKCIPHER_BLOCK_SIZE];

--- a/benchmark/src/polyval.c
+++ b/benchmark/src/polyval.c
@@ -10,7 +10,7 @@
 
 #ifdef __x86_64__
 asmlinkage void clmul_polyval_update(const u8 *in,
-				     const union polyval_key *keys,
+				     const struct polyval_key *keys,
 				     uint64_t nbytes, const u8 *final,
 				     ble128 *accumulator);
 asmlinkage void clmul_polyval_mul(ble128 *op1, const ble128 *op2);
@@ -19,7 +19,7 @@ asmlinkage void clmul_polyval_mul(ble128 *op1, const ble128 *op2);
 #endif
 #ifdef __aarch64__
 asmlinkage void pmull_polyval_update(const u8 *in,
-				     const union polyval_key *keys,
+				     const struct polyval_key *keys,
 				     uint64_t nbytes, const u8 *final,
 				     ble128 *accumulator);
 asmlinkage void pmull_polyval_mul(ble128 *op1, const ble128 *op2);
@@ -41,9 +41,9 @@ void reverse_bytes(be128 *a)
 	a->b = __builtin_bswap64(a->b);
 }
 
-static void polyval_setkey_generic(union polyval_key *key, const u8 *raw_key)
+static void polyval_setkey_generic(struct polyval_key *key, const u8 *raw_key)
 {
-	be128 *h = &key->generic_h;
+	be128 *h = &key->key.generic_h;
 
 	memcpy(h, raw_key, sizeof(be128));
 
@@ -51,9 +51,9 @@ static void polyval_setkey_generic(union polyval_key *key, const u8 *raw_key)
 	gf128mul_x_lle(h, h);
 }
 
-static void polyval_setkey_simd(union polyval_key *key, const u8 *raw_key)
+static void polyval_setkey_simd(struct polyval_key *key, const u8 *raw_key)
 {
-	ble128 *powers = key->simd_powers;
+	ble128 *powers = key->key.simd_powers;
 
 	/* set h */
 	memcpy(&powers[NUM_PRECOMPUTE_KEYS - 1], raw_key, sizeof(ble128));
@@ -66,7 +66,7 @@ static void polyval_setkey_simd(union polyval_key *key, const u8 *raw_key)
 	}
 }
 
-void polyval_setkey(union polyval_key *key, const u8 *raw_key, bool simd)
+void polyval_setkey(struct polyval_key *key, const u8 *raw_key, bool simd)
 {
 	if (simd) {
 		polyval_setkey_simd(key, raw_key);
@@ -75,10 +75,10 @@ void polyval_setkey(union polyval_key *key, const u8 *raw_key, bool simd)
 	}
 }
 
-void polyval_generic(const u8 *in, const union polyval_key *key,
+void polyval_generic(const u8 *in, const struct polyval_key *key,
 		     uint64_t nbytes, const u8 *final, be128 *accumulator)
 {
-	const be128 *h = &key->generic_h;
+	const be128 *h = &key->key.generic_h;
 	size_t nblocks = nbytes / POLYVAL_BLOCK_SIZE;
 	size_t partial = nbytes % POLYVAL_BLOCK_SIZE;
 	be128 tmp;
@@ -105,33 +105,33 @@ void polyval_generic(const u8 *in, const union polyval_key *key,
  * padded and passed as final_block. This allows callers of polyval to use
  * their own padding method without paying any additional performance cost.
  */
-void polyval_update(union polyval_state *state, const union polyval_key *key,
+void polyval_update(struct polyval_state *state, const struct polyval_key *key,
 		    const u8 *in, size_t nbytes,
 		    const u8 final_block[POLYVAL_BLOCK_SIZE], bool simd)
 {
 	if (simd) {
-		POLYVAL(in, key, nbytes, final_block, &state->simd_state);
+		POLYVAL(in, key, nbytes, final_block, &state->state.simd_state);
 	} else {
 		polyval_generic(in, key, nbytes, final_block,
-				&state->generic_state);
+				&state->state.generic_state);
 	}
 }
 
-void polyval_emit(union polyval_state *state, u8 out[POLYVAL_DIGEST_SIZE],
+void polyval_emit(struct polyval_state *state, u8 out[POLYVAL_DIGEST_SIZE],
 		  bool simd)
 {
 	if (!simd) {
-		reverse_bytes(&state->generic_state);
-		memcpy(out, &state->generic_state, POLYVAL_DIGEST_SIZE);
+		reverse_bytes(&state->state.generic_state);
+		memcpy(out, &state->state.generic_state, POLYVAL_DIGEST_SIZE);
 	} else {
-		memcpy(out, &state->simd_state, POLYVAL_DIGEST_SIZE);
+		memcpy(out, &state->state.simd_state, POLYVAL_DIGEST_SIZE);
 	}
 }
 
-static void _polyval(const union polyval_key *key, const void *src,
+static void _polyval(const struct polyval_key *key, const void *src,
 		     unsigned int srclen, u8 *digest, bool simd)
 {
-	union polyval_state polystate;
+	struct polyval_state polystate;
 	polyval_init(&polystate);
 
 	// Pad partial blocks since polyval can only handle 16-byte multiples.
@@ -145,13 +145,13 @@ static void _polyval(const union polyval_key *key, const void *src,
 	polyval_emit(&polystate, digest, simd);
 }
 
-static void _polyval_generic(const union polyval_key *key, const void *src,
+static void _polyval_generic(const struct polyval_key *key, const void *src,
 			     unsigned int srclen, u8 *digest)
 {
 	_polyval(key, src, srclen, digest, false);
 }
 
-static void _polyval_simd(const union polyval_key *key, const void *src,
+static void _polyval_simd(const struct polyval_key *key, const void *src,
 			  unsigned int srclen, u8 *digest)
 {
 	_polyval(key, src, srclen, digest, true);
@@ -163,7 +163,7 @@ void test_polyval(void)
 #define HASH _polyval_generic
 #define HASH_SIMD _polyval_simd
 #define SIMD_IMPL_NAME "clmul"
-#define KEY union polyval_key
+#define KEY struct polyval_key
 #define SETKEY polyval_setkey_generic
 #define SETKEY_SIMD polyval_setkey_simd
 #define KEY_BYTES POLYVAL_KEY_SIZE

--- a/benchmark/src/polyval.h
+++ b/benchmark/src/polyval.h
@@ -35,7 +35,7 @@ union polyval_key {
 	 */
 	ble128 simd_powers[NUM_PRECOMPUTE_KEYS];
 	/*
-	 * Array of polynomials stored in little-little endian.
+	 * Polynomial stored in little-little endian.
 	 *
 	 * The polynomial x^128 is represented in memory as
 	 * [0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
@@ -44,10 +44,10 @@ union polyval_key {
 	 * [0x80 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
 	 *  0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 ]
 	 *
-	 * The array contains the polynomials h^n .. h^1
-	 * in decreasing order of degree.
+	 * We don't need any higher powers of h since
+	 * the generic implementation is not parallelized.
 	 */
-	be128 generic_powers[NUM_PRECOMPUTE_KEYS];
+	be128 generic_h;
 };
 
 union polyval_state {

--- a/benchmark/src/polyval.h
+++ b/benchmark/src/polyval.h
@@ -14,29 +14,59 @@
 #define POLYVAL_DIGEST_SIZE 16
 #define POLYVAL_KEY_SIZE 16
 
-struct polyval_key {
+/*
+ * Polynomials are represented differently depending on whether
+ * we're using the accelerated POLYVAL implementation or the generic
+ * GHASH-like implementation.
+ */
+union polyval_key {
 	/*
-	 * h^N, ..., h in reverse order
+	 * Array of montgomery-form polynomials stored in big-little endian.
+	 *
+	 * The polynomial x^128 is represented in memory as
+	 * [0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
+	 *  0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x80 ]
+	 * The polynomial 1 is represented in memory as
+	 * [0x01 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
+	 *  0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 ]
+	 *
+	 * The array contains the polynomials h^n .. h^1
+	 * in decreasing order of degree.
 	 */
-	u128 powers[NUM_PRECOMPUTE_KEYS];
+	ble128 simd_powers[NUM_PRECOMPUTE_KEYS];
+	/*
+	 * Array of polynomials stored in little-little endian.
+	 *
+	 * The polynomial x^128 is represented in memory as
+	 * [0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
+	 *  0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x01 ]
+	 * The polynomial 1 is represented in memory as
+	 * [0x80 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 |
+	 *  0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 ]
+	 *
+	 * The array contains the polynomials h^n .. h^1
+	 * in decreasing order of degree.
+	 */
+	be128 generic_powers[NUM_PRECOMPUTE_KEYS];
 };
 
-struct polyval_state {
-	u128 state;
+union polyval_state {
+	ble128 simd_state;
+	be128 generic_state;
 };
 
 void reverse_bytes(be128 *a);
 
-static inline void polyval_init(struct polyval_state *state)
+static inline void polyval_init(union polyval_state *state)
 {
 	memset(state, 0, sizeof(*state));
 }
 
-void polyval_setkey(struct polyval_key *key, const u8 *raw_key, bool simd);
+void polyval_setkey(union polyval_key *key, const u8 *raw_key, bool simd);
 
-void polyval_update(struct polyval_state *state, const struct polyval_key *key,
+void polyval_update(union polyval_state *state, const union polyval_key *key,
 		    const u8 *in, size_t nbytes,
 		    const u8 final_block[POLYVAL_BLOCK_SIZE], bool simd);
 
-void polyval_emit(struct polyval_state *state, u8 out[POLYVAL_DIGEST_SIZE],
+void polyval_emit(union polyval_state *state, u8 out[POLYVAL_DIGEST_SIZE],
 		  bool simd);

--- a/benchmark/src/x86_64/polyval-clmulni_asm.S
+++ b/benchmark/src/x86_64/polyval-clmulni_asm.S
@@ -261,7 +261,7 @@ Lgstar:
  * If op1, op2 are in montgomery form,  this computes the montgomery
  * form of op1*op2.
  *
- * void clmul_polyval_mul(u128* op1, const u128* op2);
+ * void clmul_polyval_mul(ble128* op1, const ble128* op2);
  */
 ENTRY(clmul_polyval_mul)
 	FRAME_BEGIN
@@ -290,7 +290,7 @@ ENDPROC(clmul_polyval_mul)
  * rcx - final block (if nbytes % 16 != 0) used to allow padding without modifying *in
  * r8 - location to XOR with evaluated polynomial
  * 
- * void clmul_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, const u8* final, u128* accumulator);
+ * void clmul_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, const u8* final, ble128* accumulator);
  */
 ENTRY(clmul_polyval_update)
 	FRAME_BEGIN


### PR DESCRIPTION
* Change polyval internals from `u128` to union of `ble128` and `be128`
* Simplify polyval generic code to be a typical implementation of horner's method
* Remove extraneous casts