### PR TITLE
Remove odd block handling by polyval and perform multiple register loads on aarch64

### DIFF
--- a/benchmark/src/aarch64/polyval-pmull_asm.S
+++ b/benchmark/src/aarch64/polyval-pmull_asm.S
@@ -122,14 +122,8 @@ GSTAR	.req	v24
 	eor		D.16b, D.16b, D.16b
 	eor		E.16b, E.16b, E.16b
 	
-	ld1		{M0.16b}, [x0], #16
-	ld1		{M1.16b}, [x0], #16
-	ld1		{M2.16b}, [x0], #16
-	ld1		{M3.16b}, [x0], #16
-	ld1		{M4.16b}, [x0], #16
-	ld1		{M5.16b}, [x0], #16
-	ld1		{M6.16b}, [x0], #16
-	ld1		{M7.16b}, [x0], #16
+	ld1		{M0.16b, M1.16b, M2.16b, M3.16b}, [x0], #64
+	ld1		{M4.16b, M5.16b, M6.16b, M7.16b}, [x0], #64
 
 	karatsuba1 M7 KEY1
 	.if(reduce)
@@ -200,15 +194,9 @@ GSTAR	.req	v24
 
 	cmp		TMP, #-4
     bgt		.gt4Partial
-	ld1		{M0.16b}, [x0], #16
-	ld1		{M1.16b}, [x0], #16
-	ld1		{M2.16b}, [x0], #16
-	ld1		{M3.16b}, [x0], #16
+	ld1		{M0.16b, M1.16b,  M2.16b, M3.16b}, [x0], #64
     // Clobber key registers
-	ld1		{KEY8.16b}, [KEY_START], #16
-	ld1		{KEY7.16b}, [KEY_START], #16
-	ld1		{KEY6.16b}, [KEY_START], #16
-	ld1		{KEY5.16b}, [KEY_START], #16
+	ld1		{KEY8.16b, KEY7.16b, KEY6.16b,  KEY5.16b}, [KEY_START], #64
 	karatsuba1 M0 KEY8
 	karatsuba1 M1 KEY7
 	karatsuba1 M2 KEY6
@@ -219,13 +207,9 @@ GSTAR	.req	v24
 .gt4Partial:
 	cmp		TMP, #-3
 	bgt		.gt3Partial
-	ld1		{M0.16b}, [x0], #16
-	ld1		{M1.16b}, [x0], #16
-	ld1		{M2.16b}, [x0], #16
+	ld1		{M0.16b, M1.16b, M2.16b}, [x0], #48
     // Clobber key registers
-	ld1		{KEY8.16b}, [KEY_START], #16
-	ld1		{KEY7.16b}, [KEY_START], #16
-	ld1		{KEY6.16b}, [KEY_START], #16
+	ld1		{KEY8.16b, KEY7.16b, KEY6.16b}, [KEY_START], #48
 	karatsuba1 M0 KEY8
 	karatsuba1 M1 KEY7
 	karatsuba1 M2 KEY6
@@ -235,11 +219,9 @@ GSTAR	.req	v24
 .gt3Partial:
 	cmp		TMP, #-2
 	bgt		.gt2Partial
-	ld1		{M0.16b}, [x0], #16
-	ld1		{M1.16b}, [x0], #16
+	ld1		{M0.16b, M1.16b}, [x0], #32
 	// Clobber key registers
-	ld1		{KEY8.16b}, [KEY_START], #16
-	ld1		{KEY7.16b}, [KEY_START], #16
+	ld1		{KEY8.16b, KEY7.16b}, [KEY_START], #32
 	karatsuba1 M0 KEY8
 	karatsuba1 M1 KEY7
 	add		IDX, IDX, #2
@@ -300,14 +282,8 @@ ENTRY(pmull_polyval_update)
 	adr		TMP, .Lgstar
 	ld1		{GSTAR.2d}, [TMP]
 	mov		KEY_START, x1
-	ld1		{KEY8.16b}, [x1], #16
-	ld1		{KEY7.16b}, [x1], #16
-	ld1		{KEY6.16b}, [x1], #16
-	ld1		{KEY5.16b}, [x1], #16
-	ld1		{KEY4.16b}, [x1], #16
-	ld1		{KEY3.16b}, [x1], #16
-	ld1		{KEY2.16b}, [x1], #16
-	ld1		{KEY1.16b}, [x1], #16
+	ld1		{KEY8.16b, KEY7.16b, KEY6.16b, KEY5.16b}, [x1], #64
+	ld1		{KEY4.16b, KEY3.16b, KEY2.16b, KEY1.16b}, [x1], #64
 	lsr		BLOCKS_LEFT, BLOCKS_LEFT, #4
 	ld1		{SUM.16b}, [x3]
 	cmp		BLOCKS_LEFT, #NUM_PRECOMPUTE_KEYS

--- a/benchmark/src/aarch64/polyval-pmull_asm.S
+++ b/benchmark/src/aarch64/polyval-pmull_asm.S
@@ -180,12 +180,8 @@ GSTAR	.req	v24
 	eor		C.16b, C.16b, C.16b
 	eor		D.16b, D.16b, D.16b
 	eor		E.16b, E.16b, E.16b
-	mov		TMP, BLOCKS_LEFT
-	cmp		EXTRA_BYTES, #0
-	csinc	TMP, TMP, TMP, eq
-	lsl		TMP, TMP, #4
     // x1 currently points at the end of the key array
-	subs	KEY_START, x1, TMP
+	subs	KEY_START, x1, BLOCKS_LEFT, lsl #4
 	ld1		{v0.16b}, [KEY_START]
 	mov		v1.16b, SUM.16b
 	karatsuba1 v0 v1
@@ -258,12 +254,6 @@ GSTAR	.req	v24
 .outPartial:
 	b .LoopPartial
 .LoopExitPartial:
-	# Handle extra block
-	cmp		EXTRA_BYTES, #0
-	beq		.no_extra_block
-	ld1		{M0.16b}, [x3]
-	karatsuba1 M0 KEY1
-.no_extra_block:
 	karatsuba2
 	montgomery_reduction
 	eor		SUM.16b, SUM.16b, PH.16b
@@ -302,10 +292,9 @@ ENDPROC(pmull_polyval_mul)
  * x0 (OP1) - pointer to message blocks
  * x1 - pointer to precomputed key struct
  * x2 - number of bytes to hash
- * x3 - final block (if nbytes % 16 != 0) used to allow padding without modifying *in
- * x4 - location to XOR with evaluated polynomial
+ * x3 - location to XOR with evaluated polynomial
  *
- * void pmull_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, const u8* final, ble128* accumulator);
+ * void pmull_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nbytes, ble128* accumulator);
  */
 ENTRY(pmull_polyval_update)
 	adr		TMP, .Lgstar
@@ -319,9 +308,8 @@ ENTRY(pmull_polyval_update)
 	ld1		{KEY3.16b}, [x1], #16
 	ld1		{KEY2.16b}, [x1], #16
 	ld1		{KEY1.16b}, [x1], #16
-	ands	EXTRA_BYTES, x2, 0xf
 	lsr		BLOCKS_LEFT, BLOCKS_LEFT, #4
-	ld1		{SUM.16b}, [x4]
+	ld1		{SUM.16b}, [x3]
 	cmp		BLOCKS_LEFT, #NUM_PRECOMPUTE_KEYS
 	blt		.StrideLoopExit
 	full_stride 0
@@ -337,13 +325,9 @@ ENTRY(pmull_polyval_update)
 	mov		SUM.16b, PH.16b
 .StrideLoopExit:
 	cmp		BLOCKS_LEFT, 0
-	bne		.DoPartial
-	cmp		EXTRA_BYTES, 0
-	bne		.DoPartial
-	b		.SkipPartial
-.DoPartial:
+	beq		.SkipPartial
 	partial_stride
 .SkipPartial:
-	st1		{SUM.16b}, [x4]
+	st1		{SUM.16b}, [x3]
 	ret
 ENDPROC(pmull_polyval_update)

--- a/benchmark/src/polyval.c
+++ b/benchmark/src/polyval.c
@@ -19,8 +19,7 @@ asmlinkage void clmul_polyval_mul(ble128 *op1, const ble128 *op2);
 #ifdef __aarch64__
 asmlinkage void pmull_polyval_update(const u8 *in,
 				     const struct polyval_key *keys,
-				     uint64_t nbytes, const u8 *final,
-				     ble128 *accumulator);
+				     uint64_t nbytes, ble128 *accumulator);
 asmlinkage void pmull_polyval_mul(ble128 *op1, const ble128 *op2);
 #define POLYVAL pmull_polyval_update
 #define MUL pmull_polyval_mul

--- a/benchmark/src/polyval.h
+++ b/benchmark/src/polyval.h
@@ -70,8 +70,7 @@ static inline void polyval_init(struct polyval_state *state)
 void polyval_setkey(struct polyval_key *key, const u8 *raw_key, bool simd);
 
 void polyval_update(struct polyval_state *state, const struct polyval_key *key,
-		    const u8 *in, size_t nbytes,
-		    const u8 final_block[POLYVAL_BLOCK_SIZE], bool simd);
+		    const u8 *in, size_t nbytes, bool simd);
 
 void polyval_emit(struct polyval_state *state, u8 out[POLYVAL_DIGEST_SIZE],
 		  bool simd);

--- a/benchmark/src/x86_64/polyval-clmulni_asm.S
+++ b/benchmark/src/x86_64/polyval-clmulni_asm.S
@@ -22,7 +22,6 @@
 
 #define BLOCKS_LEFT %rdx
 #define OP1 %rdi
-#define EXTRA_BYTES %r9
 #define OP2 %r10
 #define IDX %r11
 #define TMP %rax
@@ -186,10 +185,6 @@ Lgstar:
 	pxor D, D
 	pxor EF, EF
 	mov BLOCKS_LEFT, TMP
-	test EXTRA_BYTES, EXTRA_BYTES
-	je .no_extra_block1
-	inc TMP
-.no_extra_block1:
 	shlq $4, TMP
 	mov %rsi, OP2
 	addq $(16*NUM_PRECOMPUTE_KEYS), OP2
@@ -243,12 +238,6 @@ Lgstar:
 .outPartial:
 	jmp .LoopPartial
 .LoopExitPartial:
-	# Handle extra block
-	test EXTRA_BYTES, EXTRA_BYTES
-	je .no_extra_block2
-	movq %rcx, OP1
-	schoolbook1 1
-.no_extra_block2:
 	schoolbook2
 	montgomery_reduction
 	pxor PH, SUM
@@ -295,10 +284,8 @@ ENDPROC(clmul_polyval_mul)
 ENTRY(clmul_polyval_update)
 	FRAME_BEGIN
 	vmovdqa Lgstar(%rip), GSTAR
-	movq $0x0f, EXTRA_BYTES
-	andq BLOCKS_LEFT, EXTRA_BYTES
 	shr $4, BLOCKS_LEFT
-	movups (%r8), SUM
+	movups (%rcx), SUM
 	cmpq $NUM_PRECOMPUTE_KEYS, BLOCKS_LEFT
 	jb .StrideLoopExit
 	full_stride 0
@@ -314,14 +301,10 @@ ENTRY(clmul_polyval_update)
 	movdqa PH, SUM
 .StrideLoopExit:
 	test BLOCKS_LEFT, BLOCKS_LEFT
-	jne .DoPartial
-	test EXTRA_BYTES, EXTRA_BYTES
-	jne .DoPartial
-	jmp .SkipPartial
-.DoPartial:
+	je .SkipPartial
 	partial_stride
 .SkipPartial:
-	movups SUM, (%r8)
+	movups SUM, (%rcx)
 	FRAME_END
 	ret
 ENDPROC(clmul_polyval_update)


### PR DESCRIPTION
* Removes polyval `final_block` handling for x86-64, aarch64 and generic
* Modifies aarch64 polyval to load multiple registers at once

Fixes #4 