### PR TITLE
Enforce no compiler warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Build benchmark tool
       run: |
         cd benchmark
-        meson build/host
+        meson build/host --werror
         ninja -C build/host
     - name: Run benchmark tool
       run: |
@@ -67,7 +67,7 @@ jobs:
     - name: Build benchmark tool
       run: |
         cd benchmark
-        ./cross-tools/setup-build --build-type=qemu-aarch64
+        ./cross-tools/setup-build --build-type=qemu-aarch64 -- --werror
         ninja -C build/qemu-aarch64
     - name: Run benchmark tool
       run: |

--- a/benchmark/cross-tools/setup-build
+++ b/benchmark/cross-tools/setup-build
@@ -29,7 +29,7 @@ def parse_args():
     parser.add_argument('--ndk-dir', type=pathlib.Path)
     parser.add_argument('--adb', default='adb')
     parser.add_argument('--meson', default='meson')
-    parser.add_argument('--meson-arg', action='append', default=[])
+    parser.add_argument('meson_arg', nargs='*')
     return parser.parse_args()
 
 

--- a/benchmark/meson.build
+++ b/benchmark/meson.build
@@ -4,7 +4,11 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-project('cipherbench', 'c')
+project('cipherbench', 'c',
+        default_options: [
+            'optimization=2',
+            'warning_level=1'
+        ])
 
 conf_data = configuration_data()
 conf_data.set10('SYMBOLS_HAVE_UNDERSCORE_PREFIX',
@@ -16,7 +20,7 @@ include_dirs = [
     include_directories('../test_vectors/converted/cstruct'),
     include_directories('../third_party/linux-kernel')
 ]
-add_project_arguments('-O2', '-Wall', '-Wno-pointer-sign', '-fno-strict-aliasing', language : 'c')
+add_project_arguments('-Wno-pointer-sign', '-fno-strict-aliasing', language : 'c')
 
 src = [
     'src/aes.c',

--- a/benchmark/src/hctr2-xctr.c
+++ b/benchmark/src/hctr2-xctr.c
@@ -38,8 +38,9 @@ static void xctr_crypt_simd(const struct aes_ctx *ctx, u8 *dst, const u8 *src,
 			    size_t nbytes, const u8 *iv)
 {
 	le128 extra;
-	size_t offset;
 #ifdef __x86_64__
+	size_t offset;
+
 	switch (ctx->aes_ctx.key_length) {
 	case AES_KEYSIZE_256:
 		aes_xctr_enc_256_avx_by8(src, iv, ctx, dst, nbytes);
@@ -73,7 +74,7 @@ static void xctr_crypt_simd(const struct aes_ctx *ctx, u8 *dst, const u8 *src,
 		memcpy(&extra, src + nbytes - tail, tail);
 	}
 	ce_aes_xctr_encrypt(dst, src, (u8 *)&ctx->aes_ctx.key_enc, rounds,
-			    nbytes, iv, &extra);
+			    nbytes, iv, (u8 *)&extra);
 	if (tail > 0 && tail < XCTR_BLOCK_SIZE) {
 		memcpy(dst + nbytes - tail, &extra, tail);
 	}


### PR DESCRIPTION
* meson.build: use built-in optimization and warning options
* setup-build: support extra meson arguments containing dashes
* hctr2-xctr.c: fix two compiler warnings
* ci.yml: use -Werror when building benchmark tool