### PR TITLE
Copyright and license header cleanups

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Google LLC
+Copyright 2021 Google LLC
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the

--- a/benchmark/src/aarch64/polyval-pmull_asm.S
+++ b/benchmark/src/aarch64/polyval-pmull_asm.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/aes.c
+++ b/benchmark/src/aes.c
@@ -1,7 +1,7 @@
 /*
  * AES block cipher (glue code)
  *
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/aes.h
+++ b/benchmark/src/aes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/asm_common.h
+++ b/benchmark/src/asm_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/cipher_benchmark_template.h
+++ b/benchmark/src/cipher_benchmark_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/cipherbench.c
+++ b/benchmark/src/cipherbench.c
@@ -1,7 +1,7 @@
 /*
  * Cryptographic benchmark program
  *
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/cipherbench.h
+++ b/benchmark/src/cipherbench.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/hash_benchmark_template.h
+++ b/benchmark/src/hash_benchmark_template.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/hctr2-xctr.c
+++ b/benchmark/src/hctr2-xctr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/hctr2-xctr.h
+++ b/benchmark/src/hctr2-xctr.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/hctr2.c
+++ b/benchmark/src/hctr2.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/hctr2_testvecs.h
+++ b/benchmark/src/hctr2_testvecs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/polyval-asm.h
+++ b/benchmark/src/polyval-asm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/polyval.c
+++ b/benchmark/src/polyval.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/polyval.h
+++ b/benchmark/src/polyval.h
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/testvec.h
+++ b/benchmark/src/testvec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/util.h
+++ b/benchmark/src/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at

--- a/benchmark/src/x86_64/polyval-clmulni_asm.S
+++ b/benchmark/src/x86_64/polyval-clmulni_asm.S
@@ -1,5 +1,6 @@
 /*
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/xts.c
+++ b/benchmark/src/xts.c
@@ -2,6 +2,7 @@
  * XTS encryption
  *
  * Copyright 2021 Google LLC
+ *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.

--- a/benchmark/src/xts.c
+++ b/benchmark/src/xts.c
@@ -5,8 +5,6 @@
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file or at
  * https://opensource.org/licenses/MIT.
- *
- * Author: Nathan Huckleberry <nhuck@google.com>
  */
 
 #include "aes.h"


### PR DESCRIPTION
* Remove (C) from copyright lines
* Remove an Author line
* Consistently have empty line between copyright line and license