### PR TITLE
benchmark: miscellaneous cleanups

### DIFF
--- a/benchmark/src/aarch64/polyval-pmull_asm.S
+++ b/benchmark/src/aarch64/polyval-pmull_asm.S
@@ -123,7 +123,7 @@ GSTAR	.req	v24
 	eor		C.16b, C.16b, C.16b
 	eor		D.16b, D.16b, D.16b
 	eor		E.16b, E.16b, E.16b
-	
+
 	ld1		{M0.16b, M1.16b, M2.16b, M3.16b}, [x0], #64
 	ld1		{M4.16b, M5.16b, M6.16b, M7.16b}, [x0], #64
 
@@ -244,13 +244,13 @@ GSTAR	.req	v24
 .endm
 
 /*
- * Perform montgomery multiplication in GF128 and store result in op1.
+ * Perform montgomery multiplication in GF(2^128) and store result in op1.
  *
  * Computes op1*op2*x^{-128} mod x^128 + x^127 + x^126 + x^121 + 1
  * If op1, op2 are in montgomery form,  this computes the montgomery
  * form of op1*op2.
  *
- * void pmull_polyval_mul(ble128* op1, const ble128* op2);
+ * void pmull_polyval_mul(ble128 *op1, const ble128 *op2);
  */
 ENTRY(pmull_polyval_mul)
 	adr		TMP, .Lgstar
@@ -268,8 +268,8 @@ ENTRY(pmull_polyval_mul)
 ENDPROC(pmull_polyval_mul)
 
 /*
- * Perform polynomial evaluation as specified by POLYVAL. Multiplies the value stored
- * at accumulator by h^n and XORs the evaluated polynomial into it.
+ * Perform polynomial evaluation as specified by POLYVAL. Multiplies the value
+ * stored at accumulator by h^n and XORs the evaluated polynomial into it.
  *
  * Computes h^k*accumulator + h^kM_0 + ... + h^1M_{k-1} (No constant term)
  *
@@ -278,7 +278,8 @@ ENDPROC(pmull_polyval_mul)
  * x2 - number of blocks to hash
  * x3 - location to XOR with evaluated polynomial
  *
- * void pmull_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nblocks, ble128* accumulator);
+ * void pmull_polyval_update(const u8 *in, const struct polyhash_key *keys,
+ *			     size_t nblocks, ble128 *accumulator);
  */
 ENTRY(pmull_polyval_update)
 	adr		TMP, .Lgstar

--- a/benchmark/src/aes.h
+++ b/benchmark/src/aes.h
@@ -17,3 +17,13 @@ struct aes_ctx {
 void aes_setkey(struct aes_ctx *ctx, const u8 *key, int key_len);
 void aes_encrypt(const struct aes_ctx *ctx, u8 *out, const u8 *in, bool simd);
 void aes_decrypt(const struct aes_ctx *ctx, u8 *out, const u8 *in, bool simd);
+
+static inline int aes_nrounds(const struct aes_ctx *ctx)
+{
+	/*
+	 * AES-128: 6 + 16 / 4 = 10 rounds
+	 * AES-192: 6 + 24 / 4 = 12 rounds
+	 * AES-256: 6 + 32 / 4 = 14 rounds
+	 */
+	return 6 + ctx->aes_ctx.key_length / 4;
+}

--- a/benchmark/src/cipherbench.c
+++ b/benchmark/src/cipherbench.c
@@ -20,8 +20,8 @@ static const struct cipher {
 	void (*test_func)(void);
 } ciphers[] = {
 	{"HCTR2", test_hctr2},
-	{"XCTR", test_xctr},
 	{"Polyval", test_polyval},
+	{"XCTR", test_xctr},
 	{"XTS", test_xts},
 };
 

--- a/benchmark/src/cipherbench.h
+++ b/benchmark/src/cipherbench.h
@@ -7,12 +7,10 @@
  */
 #pragma once
 
+void test_hctr2(void);
 void test_polyval(void);
 void test_xctr(void);
-void test_hctr2(void);
 void test_xts(void);
-
-void do_insn_timing(void);
 
 struct cipherbench_params {
 	int bufsize;

--- a/benchmark/src/hctr2.c
+++ b/benchmark/src/hctr2.c
@@ -32,8 +32,8 @@ struct hctr2_ctx {
  * The two computed states are used as the polynomial hash function's initial
  * state.
  */
-void hctr2_change_tweak_len(struct hctr2_ctx *ctx, const size_t tweak_len,
-			    bool simd)
+static void hctr2_change_tweak_len(struct hctr2_ctx *ctx,
+				   const size_t tweak_len, bool simd)
 {
 	le128 tmp;
 
@@ -50,8 +50,8 @@ void hctr2_change_tweak_len(struct hctr2_ctx *ctx, const size_t tweak_len,
 		       1, simd);
 }
 
-void hctr2_setkey(struct hctr2_ctx *ctx, const u8 *key, size_t key_len,
-		  bool simd)
+static void hctr2_setkey(struct hctr2_ctx *ctx, const u8 *key, size_t key_len,
+			 bool simd)
 {
 	u8 hbar[BLOCKCIPHER_BLOCK_SIZE];
 
@@ -101,9 +101,9 @@ static void hctr2_hash_message(const struct hctr2_ctx *ctx,
 	}
 }
 
-void hctr2_crypt(const struct hctr2_ctx *ctx, u8 *dst, const u8 *src,
-		 size_t nbytes, const u8 *tweak, size_t tweak_len, bool encrypt,
-		 bool simd)
+static void hctr2_crypt(const struct hctr2_ctx *ctx, u8 *dst, const u8 *src,
+			size_t nbytes, const u8 *tweak, size_t tweak_len,
+			bool encrypt, bool simd)
 {
 	struct polyval_state polystate1;
 	struct polyval_state polystate2;
@@ -156,11 +156,10 @@ void hctr2_crypt(const struct hctr2_ctx *ctx, u8 *dst, const u8 *src,
 
 	xor(&MM, M, digest, BLOCKCIPHER_BLOCK_SIZE);
 
-	if (encrypt) {
+	if (encrypt)
 		aes_encrypt(&ctx->aes_ctx, UU, MM, simd);
-	} else {
+	else
 		aes_decrypt(&ctx->aes_ctx, UU, MM, simd);
-	}
 
 	xor(&S, &MM, &UU, BLOCKCIPHER_BLOCK_SIZE);
 	xor(&S, &ctx->L, &S, BLOCKCIPHER_BLOCK_SIZE);
@@ -273,7 +272,6 @@ static void test_hctr2_testvecs(void)
 		test_hctr2_testvec(&hctr2_aes256_tv[i], AES_KEYSIZE_256, true);
 	}
 }
-
 
 void test_hctr2(void)
 {

--- a/benchmark/src/polyval.h
+++ b/benchmark/src/polyval.h
@@ -61,8 +61,6 @@ struct polyval_state {
 	} state;
 };
 
-void reverse_bytes(be128 *a);
-
 static inline void polyval_init(struct polyval_state *state)
 {
 	memset(state, 0, sizeof(*state));

--- a/benchmark/src/x86_64/polyval-clmulni_asm.S
+++ b/benchmark/src/x86_64/polyval-clmulni_asm.S
@@ -103,7 +103,7 @@ Lgstar:
 
 /*
  * Computes the 128-bit reduction of PL, PH. Stores the result in PH.
- * 
+ *
  * PL, PH, Z, T.
  * All other xmm registers are preserved.
  */
@@ -204,7 +204,7 @@ Lgstar:
 .LloopPartial:
 	cmpq BLOCKS_LEFT, IDX # IDX < rdx
 	jae .LloopExitPartial
-	
+
 	movq BLOCKS_LEFT, TMP
 	subq IDX, TMP # TMP = rdx - IDX
 
@@ -245,13 +245,13 @@ Lgstar:
 .endm
 
 /*
- * Perform montgomery multiplication in GF128 and store result in op1.
+ * Perform montgomery multiplication in GF(2^128) and store result in op1.
  *
  * Computes op1*op2*x^{-128} mod x^128 + x^127 + x^126 + x^121 + 1
  * If op1, op2 are in montgomery form,  this computes the montgomery
  * form of op1*op2.
  *
- * void clmul_polyval_mul(ble128* op1, const ble128* op2);
+ * void clmul_polyval_mul(ble128 *op1, const ble128 *op2);
  */
 ENTRY(clmul_polyval_mul)
 	FRAME_BEGIN
@@ -268,9 +268,9 @@ ENTRY(clmul_polyval_mul)
 	ret
 ENDPROC(clmul_polyval_mul)
 
-/* 
- * Perform polynomial evaluation as specified by POLYVAL. Multiplies the value stored
- * at accumulator by h^k and XORs the evaluated polynomial into it.
+/*
+ * Perform polynomial evaluation as specified by POLYVAL. Multiplies the value
+ * stored at accumulator by h^k and XORs the evaluated polynomial into it.
  *
  * Computes h^k*accumulator + h^kM_0 + ... + h^1M_{k-1} (No constant term)
  *
@@ -278,8 +278,9 @@ ENDPROC(clmul_polyval_mul)
  * rsi - pointer to precomputed key struct
  * rdx - number of blocks to hash
  * rcx - location to XOR with evaluated polynomial
- * 
- * void clmul_polyval_update(const u8 *in, const struct polyhash_key* keys, uint64_t nblocks, ble128* accumulator);
+ *
+ * void clmul_polyval_update(const u8 *in, const struct polyhash_key* keys,
+ *			     size_t nblocks, ble128* accumulator);
  */
 ENTRY(clmul_polyval_update)
 	FRAME_BEGIN

--- a/benchmark/src/xctr.h
+++ b/benchmark/src/xctr.h
@@ -13,7 +13,5 @@
 #define XCTR_IV_SIZE 16
 #define XCTR_BLOCK_SIZE 16
 
-void xctr_setkey(struct aes_ctx *ctx, const u8 *key, size_t key_len);
-
 void xctr_crypt(const struct aes_ctx *ctx, u8 *dst, const u8 *src,
 		size_t nbytes, const u8 *iv, bool simd);

--- a/third_party/linux-kernel/aes_linux.h
+++ b/third_party/linux-kernel/aes_linux.h
@@ -25,16 +25,6 @@ struct crypto_aes_ctx {
 	u32 key_length;
 };
 
-static inline int aes_nrounds(const struct crypto_aes_ctx *ctx)
-{
-	/*
-	 * AES-128: 6 + 16 / 4 = 10 rounds
-	 * AES-192: 6 + 24 / 4 = 12 rounds
-	 * AES-256: 6 + 32 / 4 = 14 rounds
-	 */
-	return 6 + ctx->key_length / 4;
-}
-
 #ifdef __x86_64__
 asmlinkage int aesni_set_key(struct crypto_aes_ctx *ctx, const u8 *in_key,
             unsigned int key_len);


### PR DESCRIPTION
- Remove trailing whitespace
- Remove unneeded braces, to align with Linux style
- Line wrap at 80 columns
- 'Use foo *bar' instead of 'foo* bar'
- GF(2^128), not GF(128)
- Consistently use size_t for sizes instead of uint64_t
- Make functions 'static' where possible
- Add empty line after variable declarations, to align with Linux style
- Use aes_nrounds() where possible, and move it to aes.h
- Put complex macro values in parentheses
- Use XTS_BLOCK_SIZE instead of hardcoding 16
- Remove xctr_setkey(); just call aes_setkey() directly
- Remove unused declaration of do_insn_timing()
- Alphabetize the algorithms
- Write "polyval_update" instead of "polyval", where warranted
- Consistently use 'if (simd)' instead of 'if (!simd)'