### PR TITLE
Fix linux testvector naming

### DIFF
--- a/python/ciphers/hctr2.py
+++ b/python/ciphers/hctr2.py
@@ -124,4 +124,4 @@ class HCTR2(ciphers.cipher.Bijection):
         }
 
     def linux_name(self):
-        return f"{self.name()}_{self._block.name()}"
+        return f"{self._block.name()}_{self.name()}"

--- a/python/ciphers/xctr.py
+++ b/python/ciphers/xctr.py
@@ -86,4 +86,4 @@ class XCTR(ciphers.cipher.Bijection):
         }
 
     def linux_name(self):
-        return f"{self.name()}_{self._block.name()}"
+        return f"{self._block.name()}_{self.name()}"


### PR DESCRIPTION
Make generated cstruct naming conventions match the linux kernel's [testmgr.h](https://raw.githubusercontent.com/torvalds/linux/master/crypto/testmgr.h).