### PR TITLE
More build and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-crypto
+        sudo apt-get install -y python3 python3-pycryptodome
     - name: Test python code
       run: |
         ./python/testvec_tool check

--- a/benchmark/src/util.h
+++ b/benchmark/src/util.h
@@ -84,19 +84,15 @@ __cold __noreturn void assertion_failed(const char *expr, const char *file,
 
 #ifdef __CHECKER__
 #define __force __attribute__((force))
-#define __bitwise__ __attribute__((bitwise))
 #else
 #define __force
-#define __bitwise__
 #endif
 
-#if !defined(__linux__)
-
-typedef u32 __bitwise__ __le32;
-typedef u64 __bitwise__ __le64;
-typedef u32 __bitwise__ __be32;
-typedef u64 __bitwise__ __be64;
-
+#ifndef __linux__
+typedef u32 __le32;
+typedef u64 __le64;
+typedef u32 __be32;
+typedef u64 __be64;
 #endif
 
 #define cpu_to_le32(v) ((__force __le32)(u32)(v))

--- a/python/ciphers/aes.py
+++ b/python/ciphers/aes.py
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import Crypto.Cipher.AES
+import Cryptodome.Cipher.AES
 
 import ciphers.cipher
 
@@ -26,10 +26,10 @@ class AES(ciphers.cipher.Blockcipher):
 
     def encrypt(self, pt, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
+        a = Cryptodome.Cipher.AES.new(key, Cryptodome.Cipher.AES.MODE_ECB)
         return a.encrypt(pt)
 
     def decrypt(self, ct, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
+        a = Cryptodome.Cipher.AES.new(key, Cryptodome.Cipher.AES.MODE_ECB)
         return a.decrypt(ct)

--- a/python/ciphers/hctr2.py
+++ b/python/ciphers/hctr2.py
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from Crypto.Util.strxor import strxor
+from Cryptodome.Util.strxor import strxor
 
 import ciphers.aes
 import ciphers.cipher

--- a/python/ciphers/xctr.py
+++ b/python/ciphers/xctr.py
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import Crypto.Util.strxor
+import Cryptodome.Util.strxor
 
 import ciphers.aes
 import ciphers.cipher
@@ -12,10 +12,10 @@ import ciphers.cipher
 
 def strxor(a, b):
     assert len(a) == len(b)
-    # Crypto.Util.strxor craps out on zero length input :(
+    # Cryptodome.Util.strxor craps out on zero length input :(
     if len(a) == 0:
         return b''
-    return Crypto.Util.strxor.strxor(a, b)
+    return Cryptodome.Util.strxor.strxor(a, b)
 
 
 class XCTR(ciphers.cipher.Bijection):


### PR DESCRIPTION
* benchmark: fix build warning with latest <linux/types.h>
* Explicitly use pycryptodome instead of pycrypto