### PR TITLE
Use red tt for binary symbols

### DIFF
--- a/paper/design.tex
+++ b/paper/design.tex
@@ -184,7 +184,7 @@ polynomial can be inferred from the degree.
 
 This change means that \(\ceil{\abs{T}/n} + \ceil{\abs{M}/n}\)
 can be inferred from the degree of the polynomial.  
-If we append a 1 to the message before padding with zeroes,
+If we append a \(\bini\) to the message before padding with zeroes,
 we need only encode only the tweak length in the length block,
 and the message length can then be inferred.
 For users whose tweaks are always the same length
@@ -195,9 +195,9 @@ precomputed.
 However, in the very common case where 
 the message length is a multiple of the block size,
 we don't want an extra multiplication
-for an extra block containing only the appended 1 bit.
+for an extra block containing only the appended \(\bini\) bit.
 Borrowing from~\cite{xcbc},
-we don't append a 1 bit to such messages.
+we don't append a \(\bini\) bit to such messages.
 Instead, we indicate whether
 the message length is a multiple of the block size
 in the least significant bit of the length block.

--- a/paper/hctr2.tex
+++ b/paper/hctr2.tex
@@ -31,12 +31,18 @@
 \usepackage{fontspec}
 \setmainfont{TeX Gyre Schola}
 \setsansfont{TeX Gyre Heros}
-\setmathrm{Latin Modern Roman}
-\setmathsf{Latin Modern Sans}
 \defaultfontfeatures{}
 \setmonofont{TeX Gyre Cursor}[Ligatures={NoCommon,NoRequired,NoContextual},Scale=0.9]
+\setmathrm{Latin Modern Roman}
+\setmathsf{Latin Modern Sans}
+\setmathtt{Latin Modern Mono}
 
 \usetikzlibrary{groupops}
+
+\newcommand{\binary}[1]{{\color{red!80!black} \mathtt{#1}}}
+\newcommand{\bino}{\binary{0}}
+\newcommand{\bini}{\binary{1}}
+\renewcommand{\bin}{\{\bino,\bini\}}
 
 \renewcommand{\pcadvantagesuperstyle}[1]{#1}
 

--- a/paper/hctrissues.tex
+++ b/paper/hctrissues.tex
@@ -37,7 +37,7 @@ Two errors in previous work on HCTR are addressed in HCTR2.
 \subsection{Hash function}\label{badhash}
 HCTR uses a hash function based on the polynomial
 \begin{displaymath}
-    H(X) = \poly(\pad(X) \Concat \fromint(\abs{X}) \Concat 0^n)
+    H(X) = \poly(\pad(X) \Concat \fromint(\abs{X}) \Concat \bino^n)
 \end{displaymath}
 Because it assumes a fixed-length tweak it simply sets \(X = M \Concat T\).
 However, HCTR requires that the resulting polynomial be nonzero
@@ -45,7 +45,7 @@ even when \(X = \lambda\),
 so as a special case \(H(\lambda) = h\).
 
 Unfortunately, as \cite{kumarhctr} observes this is no longer
-an injective map from \(X\)---we also have \(H(0) = h\). This
+an injective map from \(X\)---we also have \(H(\bino) = h\). This
 breaks the almost-XOR-universal property relied on
 in the security bound and
 straightforwardly leads to an attack in which two encryption queries

--- a/paper/injective.tex
+++ b/paper/injective.tex
@@ -17,24 +17,24 @@ a binary string \(X\) of length \(\abs{X} = n (1 + \deg(H(T, M)))\)
 representing the coefficients of 
 the polynomial \(H(T, M)\) in binary form,
 starting with the greatest nonzero power; thus
-\(13\hpoly^3\) would encode as \(1011 \Concat 0^{4n -4}\).
+\(13\hpoly^3\) would encode as \(\binary{1011} \Concat \bino^{4n -4}\).
 \begin{algorithmic}[1]
     \Procedure{GetTM}{$X$}
     \State \textbf{assert} \(\abs{X} \bmod n = 0\)
     \State \textbf{assert} \(\abs{X} \geq 2n\)
-    \State \textbf{assert} \(X[\abs{X} - n; n] = 0^n\)
+    \State \textbf{assert} \(X[\abs{X} - n; n] = \bino^n\)
     \State \(t \gets \fromint^{-1}_{n-1}(X[1;n-1])\)
     \State \textbf{assert} \(t > 0\)
     \State \(t \gets t-1\)
     \State \(w \gets n(1 + \ceil{t/n})\)
-    \If{\(X[0; 1] = 0\)}
+    \If{\(X[0; 1] = \bino\)}
         \State \textbf{assert} \(w + n \leq \abs{X}\)
         \State \(M \gets X[w;\abs{X}-w-n]\)
     \Else
         \State \textbf{assert} \(w + 2n \leq \abs{X}\)
-        \State \textbf{assert} \(X[\abs{X}-2n+1; n-1] \neq 0^{n-1}\)
+        \State \textbf{assert} \(X[\abs{X}-2n+1; n-1] \neq \bino^{n-1}\)
         \State \(i \gets \abs{X} - n - 1\)
-        \While{\(X[i; 1] = 0\)}
+        \While{\(X[i; 1] = \bino\)}
             \State \(i \gets i - 1\)
         \EndWhile
         \State \(M \gets X[w;i - w]\)

--- a/paper/security.tex
+++ b/paper/security.tex
@@ -97,7 +97,7 @@ in value if \(\hpoly = 1\),
 they are not equal as formal polynomials;
 two formal polynomials are only equal
 if every coefficient is equal. Thus \(\poly(M) = \poly(M')\)
-only if \(M = 0^{ln} \Concat M'\) for some \(l\) or vice versa.
+only if \(M = \bino^{ln} \Concat M'\) for some \(l\) or vice versa.
 
 Define \(H(T, M)\) as the formal polynomial in \(\hpoly\) given
 by that tweak and message.
@@ -108,9 +108,9 @@ performance reasons.
     & H(T, M) \\
     \defeq &
     \begin{cases}
-        \poly(\fromint(2\abs{T} + 2) \Concat \pad(T) \Concat M \Concat 0^n) &
+        \poly(\fromint(2\abs{T} + 2) \Concat \pad(T) \Concat M \Concat \bino^n) &
         \text{if } n \text{ divides } \abs{M} \\
-        \poly(\fromint(2\abs{T} + 3) \Concat \pad(T) \Concat \pad(M \Concat 1) \Concat 0^n) &
+        \poly(\fromint(2\abs{T} + 3) \Concat \pad(T) \Concat \pad(M \Concat \bini) \Concat \bino^n) &
         \text{otherwise}
     \end{cases}
 \end{align*}

--- a/paper/specification.tex
+++ b/paper/specification.tex
@@ -14,6 +14,7 @@
 \subfile{algorithm.tex}
 \subsection{Notation}
 \begin{itemize}
+    \item \(\bin^{*}\): set of binary strings
     \item $\abs{X}$: length of $X \in \bin^{*}$ in bits
     \item $\lambda$: the empty string $\abs{\lambda} = 0$
     \item $X[a;l]$: the substring of $X$ of length $l$ starting at the 0-based index $a$
@@ -23,7 +24,7 @@
     \item $\fromint_l: \{0 \ldots 2^l-1\} \rightarrow \bin^l$:
     little-endian conversion of integers to binary; 
     \(\fromint(x)\) means \(\fromint_n(x)\)
-    \item $\pad(X) = X \Concat 0^v$
+    \item $\pad(X) = X \Concat \bino^v$
     where $v$ is the least integer $\geq 0$ such that $n$ divides $\abs{X} + v$
     \item \(x, x^2, \ldots\): elements of the finite field \(\GF(2^n)\)
     \item \(E: \mathcal{K} \times \bin^n \rightarrow \bin^n\): 
@@ -41,10 +42,10 @@ $a \in A$ then $f_a: B \rightarrow C$, and if $f_a^{-1}$ exists then $f_a^{-1}(f
 
 \subsection{Polynomial hash function}\label{hashspec}
 We interpret \(n\)-bit blocks as little-endian field elements of \(\GF(2^n)\),
-so \(001 \Concat 0^{n-3}\) is interpreted as the element \(x^2\).
+so \(\binary{001} \Concat \bino^{n-3}\) is interpreted as the element \(x^2\).
 Per \cite{aes_gcm_siv,aes_gcm_siv_rfc} we define
 \begin{align*}
-    \POLYVAL(\hgen, \lambda) & = 0^n\\
+    \POLYVAL(\hgen, \lambda) & = \bino^n\\
     \POLYVAL(\hgen, A \Concat B) & = (\POLYVAL(\hgen, A) \xor B) \otimes \hgen \otimes x^{-n}
 \end{align*}
 where \(\abs{\hgen} = \abs{B} = n\) and
@@ -61,7 +62,7 @@ For hash key \(\hgen \in \bin^n\), tweak \(T\) and message \(M\), we define:
     \begin{cases}
         \POLYVAL(\hgen, \fromint(2\abs{T} + 2) \Concat \pad(T) \Concat M) &
         \text{if } n \text{ divides } \abs{M} \\
-        \POLYVAL(\hgen, \fromint(2\abs{T} + 3) \Concat \pad(T) \Concat \pad(M \Concat 1)) &
+        \POLYVAL(\hgen, \fromint(2\abs{T} + 3) \Concat \pad(T) \Concat \pad(M \Concat \bini)) &
         \text{otherwise}
     \end{cases}
 \end{align*}


### PR DESCRIPTION
It's confusing that we use the same symbols for the integers 0 and 1 as for the elements of the binary alphabet, eg in constructions like `\(0^n\)`. Make the binary symbols distinct, by using a typewriter font and coloring them differently.