### PR TITLE
ci.yml: upgrade to actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test python code
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -35,7 +35,7 @@ jobs:
     name: Build and run benchmark tool (x86_64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -53,7 +53,7 @@ jobs:
     name: Build and run benchmark tool (qemu-aarch64)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -73,7 +73,7 @@ jobs:
     name: Build and run benchmark tool (x86_64, valgrind enabled)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -93,7 +93,7 @@ jobs:
     name: Build and run benchmark tool (x86_64, UBSAN enabled)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -112,7 +112,7 @@ jobs:
     name: Build and run benchmark tool (x86_64, ASAN enabled)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -131,7 +131,7 @@ jobs:
     name: Check LaTeX sources
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y $CRYPTOBENCH_DEPENDENCIES clang
+    - name: Work around https://github.com/actions/runner-images/issues/9491
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Build benchmark tool
       run: |
         cd benchmark


### PR DESCRIPTION
This avoids another warning from GitHub Actions about a Node.js version deprecation.