### PR TITLE
Revert "ci.yml: work around ASAN binaries crashing on ubuntu-latest"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,6 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y $CRYPTOBENCH_DEPENDENCIES clang
-    - name: Work around https://github.com/actions/runner-images/issues/9491
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - name: Build benchmark tool
       run: |
         cd benchmark


### PR DESCRIPTION
This reverts commit fac589e7b88622bda42fb0b9ab3192803363987f since it is no longer needed.