### PR TITLE
Fix LaTeX error in hctr2.tex

### DIFF
--- a/paper/hctr2.tex
+++ b/paper/hctr2.tex
@@ -19,8 +19,8 @@
 \usepackage[style=alphabetic,backend=biber,alldates=ymd]{biblatex}
 \usepackage{bm}
 \usepackage[logic,probability,advantage,adversary,landau,sets,operators]{cryptocode}
-\usepackage{hyperxmp}
 \usepackage{hyperref}
+\usepackage{hyperxmp}
 \usepackage{tikz}
 
 \usepackage[parfill]{parskip}


### PR DESCRIPTION
On ubuntu-latest, ./paper/build.sh is failing with the following error:

    ! Package hyperxmp Error: hyperref must be loaded before hyperxmp.